### PR TITLE
Issue89/updates to wpi lib 202411

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -1,6 +1,6 @@
 {
     "enableCppIntellisense": false,
     "currentLanguage": "java",
-    "projectYear": "2024beta",
+    "projectYear": "2024",
     "teamNumber": 151
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2024.1.1-beta-4"
+    id "edu.wpi.first.GradleRIO" version "2024.1.1"
     id 'com.diffplug.spotless' version '6.16.0'
     id "com.github.spotbugs" version "5.2.3"
     id "jacoco"

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,13 @@ dependencies {
     nativeRelease wpi.java.vendor.jniRelease(wpi.platforms.desktop)
     simulationRelease wpi.sim.enableRelease()
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+
+    //testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    //testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     compileOnly 'net.jcip:jcip-annotations:1.0'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,8 @@ dependencies {
     simulationRelease wpi.sim.enableRelease()
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-
-    //testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    //testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    // testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
     compileOnly 'net.jcip:jcip-annotations:1.0'
     compileOnly 'com.github.spotbugs:spotbugs-annotations:4.7.3'
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -4,8 +4,8 @@
 
 package frc.robot;
 
+import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.PowerDistribution;
 import edu.wpi.first.wpilibj.XboxController;

--- a/src/main/java/frc/robot/subsystems/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmSubsystem.java
@@ -4,8 +4,8 @@
 
 package frc.robot.subsystems;
 
+import com.revrobotics.CANSparkBase.IdleMode;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.RelativeEncoder;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.ArmFeedforward;
@@ -88,7 +88,7 @@ import frc.robot.Constants.ArmConstants;
  *   - {@code private double newFeedforward}: The calculated feedforward value.
  *   - {@code private boolean armEnabled}: A flag indicating whether the arm is enabled.
  *   - {@code private double voltageCommand}: The motor commanded voltage.
- *</pre>
+ * </pre>
  */
 public class ArmSubsystem extends SubsystemBase implements AutoCloseable {
   private final CANSparkMax motor;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -13,7 +13,6 @@ import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
 import edu.wpi.first.wpilibj.ADXRS450_Gyro;
 import edu.wpi.first.wpilibj.drive.DifferentialDrive;
-import edu.wpi.first.wpilibj.motorcontrol.MotorControllerGroup;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.DriveConstants;
@@ -29,13 +28,7 @@ public class DriveSubsystem extends SubsystemBase {
   private final CANSparkMax rearRight =
       new CANSparkMax(DriveConstants.REAR_RIGHT_MOTOR_PORT, MotorType.kBrushless);
 
-  private final MotorControllerGroup leftMotorControllerGroup =
-      new MotorControllerGroup(frontLeft, rearLeft);
-  private final MotorControllerGroup rightMotorControllerGroup =
-      new MotorControllerGroup(frontRight, rearRight);
-
-  private final DifferentialDrive drive =
-      new DifferentialDrive(leftMotorControllerGroup, rightMotorControllerGroup);
+  private final DifferentialDrive drive = new DifferentialDrive(frontLeft, frontRight);
 
   // The front-left-side drive encoder
   private final RelativeEncoder frontLeftEncoder = this.frontLeft.getEncoder();
@@ -98,7 +91,7 @@ public class DriveSubsystem extends SubsystemBase {
     // We need to invert one side of the drivetrain so that positive voltages
     // result in both sides moving forward. Depending on how your robot's
     // gearbox is constructed, you might have to invert the left side instead.
-    rightMotorControllerGroup.setInverted(true);
+    frontRight.setInverted(true);
 
     SmartDashboard.putData(this.drive);
   }
@@ -168,8 +161,8 @@ public class DriveSubsystem extends SubsystemBase {
    * @param rightVolts the commanded right output
    */
   public void tankDriveVolts(double leftVolts, double rightVolts) {
-    leftMotorControllerGroup.setVoltage(leftVolts);
-    rightMotorControllerGroup.setVoltage(rightVolts);
+    frontLeft.setVoltage(leftVolts);
+    frontRight.setVoltage(rightVolts);
     drive.feed();
   }
 
@@ -255,7 +248,7 @@ public class DriveSubsystem extends SubsystemBase {
    * @return command to the left motor controller group in volts
    */
   public double getLeftMotorVolts() {
-    return leftMotorControllerGroup.get();
+    return frontLeft.get();
   }
 
   /**
@@ -264,6 +257,6 @@ public class DriveSubsystem extends SubsystemBase {
    * @return command to the right motor controller group in volts
    */
   public double getRightMotorVolts() {
-    return rightMotorControllerGroup.get();
+    return frontRight.get();
   }
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -4,9 +4,9 @@
 
 package frc.robot.subsystems;
 
+import com.revrobotics.CANSparkBase.IdleMode;
+import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.IdleMode;
-import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.RelativeEncoder;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.DifferentialDriveOdometry;

--- a/vendordeps/REVLib.json
+++ b/vendordeps/REVLib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "REVLib.json",
     "name": "REVLib",
-    "version": "2024.0.0",
+    "version": "2024.2.0",
     "frcYear": "2024",
     "uuid": "3f48eb8c-50fe-43a6-9cb7-44c86353c4cb",
     "mavenUrls": [
@@ -12,14 +12,14 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-java",
-            "version": "2024.0.0"
+            "version": "2024.2.0"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -37,7 +37,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-cpp",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "libName": "REVLib",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -55,7 +55,7 @@
         {
             "groupId": "com.revrobotics.frc",
             "artifactId": "REVLib-driver",
-            "version": "2024.0.0",
+            "version": "2024.2.0",
             "libName": "REVLibDriver",
             "headerClassifier": "headers",
             "sharedLibrary": false,


### PR DESCRIPTION
Updated for WPILib 2024.1.1:
- Switch to RevLib 2024.2.0
- Remove deprecated motorControllerGroup which is no longer needed with follow()
- Switch to Junit 1.10.1